### PR TITLE
Reformat Ruby files for line length of 120

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -19,8 +19,7 @@ Layout/HashAlignment:
     - key
 
 Layout/LineLength:
-  Exclude:
-    - "*.gemspec"
+  Max: 120
 
 Layout/SpaceAroundEqualsInParameterDefault:
   EnforcedStyle: no_space

--- a/Rakefile
+++ b/Rakefile
@@ -31,12 +31,9 @@ namespace :bump do
     lowest_minor = RubyVersions.lowest_supported_minor
     latest = RubyVersions.latest
 
-    replace_in_file "example.gemspec",
-                    /ruby_version = ">= (.*)"/ => lowest
-
+    replace_in_file "example.gemspec", /ruby_version = ">= (.*)"/ => lowest
     replace_in_file ".rubocop.yml", /TargetRubyVersion: (.*)/ => lowest_minor
-    replace_in_file ".circleci/config.yml",
-                    %r{circleci/ruby:([\d\.]+)} => latest
+    replace_in_file ".circleci/config.yml", %r{circleci/ruby:([\d\.]+)} => latest
 
     travis = YAML.safe_load(open(".travis.yml"))
     travis["rvm"] = RubyVersions.latest_supported_patches + ["ruby-head"]
@@ -87,9 +84,7 @@ module RubyVersions
 
     def versions
       @_versions ||= begin
-        yaml = URI.open(
-          "https://raw.githubusercontent.com/ruby/www.ruby-lang.org/master/_data/downloads.yml"
-        )
+        yaml = URI.open("https://raw.githubusercontent.com/ruby/www.ruby-lang.org/master/_data/downloads.yml")
         YAML.safe_load(yaml, symbolize_names: true)
       end
     end

--- a/rename_template.rb
+++ b/rename_template.rb
@@ -10,9 +10,7 @@ gemfile do
   gem "octokit", "~> 4.14"
 end
 
-# rubocop:disable Metrics/AbcSize
-# rubocop:disable Metrics/MethodLength
-def main
+def main # rubocop:disable Metrics/AbcSize, Metrics/MethodLength
   assert_git_repo!
   git_meta = read_git_data
 
@@ -136,8 +134,6 @@ def main
 
   MESSAGE
 end
-# rubocop:enable Metrics/AbcSize
-# rubocop:enable Metrics/MethodLength
 
 def assert_git_repo!
   return if File.file?(".git/config")

--- a/test/support/reporters.rb
+++ b/test/support/reporters.rb
@@ -1,7 +1,2 @@
 require "minitest/reporters"
-
-Minitest::Reporters.use!(
-  Minitest::Reporters::SpecReporter.new,
-  ENV,
-  Minitest.backtrace_filter
-)
+Minitest::Reporters.use!(Minitest::Reporters::SpecReporter.new, ENV, Minitest.backtrace_filter)


### PR DESCRIPTION
The rubocop community has decided to standardize on 120 characters for default line length.

https://github.com/rubocop-hq/rubocop/pull/7952

Update rubocop config and reformat ruby files to embrace this convention.