### PR TITLE
Adopt new gemspec/Gemfile standards

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,2 +1,11 @@
 source "https://rubygems.org"
 gemspec
+
+gem "bundler", "~> 2.0"
+gem "minitest", "~> 5.11"
+gem "minitest-ci", "~> 3.4"
+gem "minitest-reporters", "~> 1.3"
+gem "rake", "~> 13.0"
+gem "rubocop", "0.86.0"
+gem "rubocop-minitest", "0.9.0"
+gem "rubocop-performance", "1.6.1"

--- a/Gemfile
+++ b/Gemfile
@@ -1,7 +1,6 @@
 source "https://rubygems.org"
 gemspec
 
-gem "bundler", "~> 2.0"
 gem "minitest", "~> 5.11"
 gem "minitest-ci", "~> 3.4"
 gem "minitest-reporters", "~> 1.3"

--- a/Rakefile
+++ b/Rakefile
@@ -31,7 +31,7 @@ namespace :bump do
     lowest_minor = RubyVersions.lowest_supported_minor
     latest = RubyVersions.latest
 
-    replace_in_file "example.gemspec", /ruby_version = ">= (.*)"/ => lowest
+    replace_in_file "example.gemspec", /ruby_version = .*">= (.*)"/ => lowest
     replace_in_file ".rubocop.yml", /TargetRubyVersion: (.*)/ => lowest_minor
     replace_in_file ".circleci/config.yml", %r{circleci/ruby:([\d.]+)} => latest
 

--- a/bin/console
+++ b/bin/console
@@ -1,6 +1,5 @@
 #!/usr/bin/env ruby
 
-gem "bundler", "~> 2.0"
 require "bundler/setup"
 require "example"
 

--- a/example.gemspec
+++ b/example.gemspec
@@ -1,22 +1,21 @@
-lib = File.expand_path("lib", __dir__)
-$LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
-require "example/version"
+require_relative "lib/example/version"
 
 Gem::Specification.new do |spec|
-  spec.name          = "example"
-  spec.version       = Example::VERSION
-  spec.authors       = ["Example Owner"]
-  spec.email         = ["owner@example.com"]
+  spec.name = "example"
+  spec.version = Example::VERSION
+  spec.authors = ["Example Owner"]
+  spec.email = ["owner@example.com"]
 
-  spec.summary       = ""
-  spec.homepage      = "https://github.com/mattbrictson/gem"
-  spec.license       = "MIT"
+  spec.summary = ""
+  spec.homepage = "https://github.com/mattbrictson/gem"
+  spec.license = "MIT"
+  spec.required_ruby_version = Gem::Requirement.new(">= 2.5.0")
 
   spec.metadata = {
     "bug_tracker_uri" => "https://github.com/mattbrictson/gem/issues",
     "changelog_uri" => "https://github.com/mattbrictson/gem/releases",
     "source_code_uri" => "https://github.com/mattbrictson/gem",
-    "homepage_uri" => "https://github.com/mattbrictson/gem"
+    "homepage_uri" => spec.homepage
   }
 
   # Specify which files should be added to the gem when it is released.
@@ -24,15 +23,4 @@ Gem::Specification.new do |spec|
   spec.bindir        = "exe"
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
-
-  spec.required_ruby_version = ">= 2.5.0"
-
-  spec.add_development_dependency "bundler", "~> 2.0"
-  spec.add_development_dependency "minitest", "~> 5.11"
-  spec.add_development_dependency "minitest-ci", "~> 3.4"
-  spec.add_development_dependency "minitest-reporters", "~> 1.3"
-  spec.add_development_dependency "rake", "~> 13.0"
-  spec.add_development_dependency "rubocop", "0.86.0"
-  spec.add_development_dependency "rubocop-minitest", "0.9.0"
-  spec.add_development_dependency "rubocop-performance", "1.6.1"
 end

--- a/example.gemspec
+++ b/example.gemspec
@@ -20,7 +20,7 @@ Gem::Specification.new do |spec|
 
   # Specify which files should be added to the gem when it is released.
   spec.files = `git ls-files -z exe lib LICENSE.txt README.md`.split("\x0")
-  spec.bindir        = "exe"
-  spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
+  spec.bindir = "exe"
+  spec.executables = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 end


### PR DESCRIPTION
These are the latest recommendations for gem development from the rubygems team:

- Place development dependencies in the `Gemfile`, not the `.gemspec`
- Do not modify the `$LOAD_PATH` in the `.gemspec`
- Use `Gem::Requirement.new` to specify Ruby requirement
- Do not include `bundler` as a development dependency