### PR TITLE
Resolves Issue #150 - Rename Template Crashes

### DIFF
--- a/rename_template.rb
+++ b/rename_template.rb
@@ -190,10 +190,10 @@ def read_git_data
   return {} unless git("remote", "-v").match?(/^origin/)
 
   origin_url = git("remote", "get-url", "origin").chomp
-  origin_repo_path = origin_url[%r{[:/]([^/]+/[^/]+)(?:\.git)$}, 1]
+  origin_repo_path = origin_url[%r{[:/]([^/]+/[^/]+?)(?:\.git)?$}, 1]
 
   {
-    origin_repo_name: origin_repo_path.split("/").last,
+    origin_repo_name: origin_repo_path&.split("/")&.last,
     origin_repo_path: origin_repo_path,
     user_email: git("config", "user.email").chomp,
     user_name: git("config", "user.name").chomp


### PR DESCRIPTION
When rename_template.rb was run with a remote repository that did not end in .git, it would previously crash.

These changes modify the regex to return the repo correctly in either case as well as providing a nil value if no repo is found without crashing.